### PR TITLE
Add Firestore security rules and indexes

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,30 @@
+{
+ "indexes": [
+ {
+ "collectionGroup": "events",
+ "queryScope": "COLLECTION",
+ "fields": [
+ {"fieldPath": "type", "order": "ASCENDING"},
+ {"fieldPath": "ts", "order": "DESCENDING"}
+ ]
+ },
+ {
+ "collectionGroup": "events",
+ "queryScope": "COLLECTION",
+ "fields": [
+ {"fieldPath": "bay_id", "order": "ASCENDING"},
+ {"fieldPath": "ts", "order": "DESCENDING"}
+ ]
+ },
+ {
+ "collectionGroup": "sessions",
+ "queryScope": "COLLECTION",
+ "fields": [
+ {"fieldPath": "active", "order": "ASCENDING"},
+ {"fieldPath": "bay_id", "order": "ASCENDING"},
+ {"fieldPath": "start_ts", "order": "DESCENDING"}
+ ]
+ }
+ ],
+ "fieldOverrides": []
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,57 @@
+rules_version = '2';
+service cloud.firestore {
+ match /databases/{database}/documents {
+ // Helper functions for roles
+ function isAdmin() {
+ return request.auth != null && request.auth.token.role == 'admin';
+ }
+ function isServer() {
+ // When using Firebase Admin SDK with custom claims
+ return request.auth != null && request.auth.token.server == true;
+ }
+ // Events collection: created by the monitoring script (server) only
+ match /events/{eventId} {
+ allow read: if isAdmin();
+ allow create: if isServer();
+ allow update, delete: if false;
+ }
+ // Sessions collection: created/updated by server or admin
+ match /sessions/{sessionId} {
+ allow read: if isAdmin();
+ allow create, update: if isAdmin() || isServer();
+ allow delete: if isAdmin();
+ }
+ // Bays collection: read/write by admin; server updates status
+ match /bays/{bayId} {
+ allow read: if isAdmin();
+ allow create, update: if isAdmin() || isServer();
+ allow delete: if isAdmin();
+ }
+ // Cars collection: read by admin; create/update by server or admin
+ match /cars/{carId} {
+ allow read: if isAdmin();
+ allow create, update: if isAdmin() || isServer();
+ allow delete: if isAdmin();
+ }
+ // Alerts collection (optional notifications)
+ match /alerts/{alertId} {
+ allow read: if isAdmin();
+ allow create, update: if isAdmin() || isServer();
+ allow delete: if isAdmin();
+ }
+ // Jobs collection (service jobs)
+ match /jobs/{jobId} {
+ allow read: if isAdmin();
+ allow create, update: if isAdmin() || isServer();
+ allow delete: if isAdmin();
+ }
+ // Settings and employees collections: admin only
+ match /settings/{docId} {
+ allow read, write: if isAdmin();
+ }
+ match /employees/{empId} {
+ allow read: if isAdmin();
+ allow create, update, delete: if isAdmin();
+ }
+ }
+}


### PR DESCRIPTION
## Summary
- add Firestore security rules defining admin and server permissions for all collections
- add Firestore indexes for events and session lookups

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a13158e6a88329a8fa2eba67f4eb26